### PR TITLE
Updating the Rosetta LaunchDaemon path.

### DIFF
--- a/pkgroot/Library/Application Support/Ptolemy/ptolemy.sh
+++ b/pkgroot/Library/Application Support/Ptolemy/ptolemy.sh
@@ -6,7 +6,7 @@ if [[ $( arch ) != arm64* ]]; then
     exit 0
 fi
 
-if [[ -f "/System/Library/LaunchDaemons/com.apple.oahd.plist" ]]; then
+if [[ -f "/Library/Apple/System/Library/LaunchDaemons/com.apple.oahd.plist" ]]; then
     echo "Rosetta launch daemon is already present"
     exit 0
 fi


### PR DESCRIPTION
From what I'm seeing on my machine the correct LD path is `/Library/Apple/System/Library/LaunchDaemons/com.apple.oahd.plist`. I'm curious if you're seeing something different?